### PR TITLE
Allow http timeouts to be set in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create a client:
 client = GraphQL::Client.new(Pathname.new('path/to/schema.json')) do
   configure do |c|
     c.url = "https://#{shopify_domain}/admin/api/graphql.json"
+    c.read_timeout = 1
     c.headers = {
       'X-Shopify-Access-Token' => shopify_token
     }

--- a/lib/graphql_client/adapters/http_adapter.rb
+++ b/lib/graphql_client/adapters/http_adapter.rb
@@ -17,6 +17,9 @@ module GraphQL
           req = build_request(query, operation_name: operation_name, variables: variables)
 
           response = Net::HTTP.start(config.url.hostname, config.url.port, use_ssl: https?) do |http|
+            http.open_timeout = config.open_timeout if config.open_timeout
+            http.read_timeout = config.read_timeout if config.read_timeout
+
             http.request(req)
           end
 

--- a/lib/graphql_client/config.rb
+++ b/lib/graphql_client/config.rb
@@ -3,7 +3,16 @@
 module GraphQL
   module Client
     class Config
-      attr_accessor :debug, :headers, :per_page, :password, :username, :url
+      attr_accessor(
+        :debug,
+        :headers,
+        :per_page,
+        :password,
+        :username,
+        :url,
+        :open_timeout,
+        :read_timeout
+      )
 
       DEFAULTS = {
         debug: false,
@@ -18,6 +27,8 @@ module GraphQL
         @per_page = @options[:per_page]
         @password = @options[:password]
         @username = @options[:username]
+        @open_timeout = @options[:open_timeout]
+        @read_timeout = @options[:read_timeout]
         @url = URI(@options[:url]) if @options[:url]
       end
 

--- a/test/graphql_client/config_test.rb
+++ b/test/graphql_client/config_test.rb
@@ -23,6 +23,30 @@ module GraphQL
         assert_kind_of URI, config.url
       end
 
+      def test_initialize_accepts_open_timeout_in_seconds
+        config = Config.new(open_timeout: 2)
+        assert_equal 2, config.open_timeout
+      end
+
+      def test_initialize_accepts_read_timeout_in_seconds
+        config = Config.new(read_timeout: 5)
+        assert_equal 5, config.read_timeout
+      end
+
+      def test_setting_open_timeout_after_initialization
+        config = Config.new
+        config.open_timeout = 2
+
+        assert_equal 2, config.open_timeout
+      end
+
+      def test_setting_read_timeout_after_initialization
+        config = Config.new
+        config.read_timeout = 5
+
+        assert_equal 5, config.read_timeout
+      end
+
       def test_url_writer_coerces_to_uri
         config = Config.new
         config.url = 'http://example.com'


### PR DESCRIPTION
The `open_timeout` and `read_timeout` defaults for `Net::HTTP` are 60s, which is ridiculous. This PR allows setting saner timeout values.