### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/lib/graphql_client/version.rb
+++ b/lib/graphql_client/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Client
-    VERSION = '0.2'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
Bump version before publishing to Shopify gems server.

Using a minor version because the changes are backwards compatible.