### PR TITLE
Fix issue regarding open_timeout not being respected

### DIFF
--- a/lib/graphql_client/version.rb
+++ b/lib/graphql_client/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Client
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
Another one of those `net/http` gotchas.

The `open_timeout` is only respected when it's supplied as part of the options when you call `Net::HTTP.start`. It is not respected when it's set inside the block of `Net::HTTP.start` (i.e. `http.open_timeout = 1`).

To their credit, `open_timeout=` is not publicly [documented](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html). But, calling it doesn't throw any errors.

This is one of those things that is hard to write test for so I left a comment in the code.

Going to release this patch under version `0.3.1`.