### PR TITLE
Don't leak internal net/http timeout errors

### DIFF
--- a/lib/graphql_client/adapters/http_adapter.rb
+++ b/lib/graphql_client/adapters/http_adapter.rb
@@ -30,12 +30,16 @@ module GraphQL
           end
 
           case response
-          when Net::HTTPOK then
+          when Net::HTTPOK
             puts "Response body: \n#{JSON.pretty_generate(JSON.parse(response.body))}" if debug?
             Response.new(response.body)
           else
             raise ClientError, response
           end
+        rescue Net::OpenTimeout
+          raise OpenTimeoutError, "timeout while waiting for a connection"
+        rescue Net::ReadTimeout
+          raise ReadTimeoutError, "timeout while waiting for a response"
         end
 
         private

--- a/lib/graphql_client/error.rb
+++ b/lib/graphql_client/error.rb
@@ -3,6 +3,8 @@
 module GraphQL
   module Client
     Error = Class.new(StandardError)
+    OpenTimeoutError = Class.new(Error)
+    ReadTimeoutError = Class.new(Error)
     ResponseError = Class.new(Error)
 
     class ClientError < Error

--- a/lib/graphql_client/version.rb
+++ b/lib/graphql_client/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Client
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/test/graphql_client/adapters/http_adapter_test.rb
+++ b/test/graphql_client/adapters/http_adapter_test.rb
@@ -83,6 +83,28 @@ module GraphQL
           assert_equal '401', exception.response.code
           assert_nil exception.response.body
         end
+
+        def test_send_request_raises_an_exception_on_net_http_open_timeout_error
+          config = Config.new(url: 'http://example.org')
+          adapter = HTTPAdapter.new(config)
+
+          stub_request(:post, 'http://example.org').to_raise(Net::OpenTimeout)
+
+          assert_raises OpenTimeoutError do
+            adapter.request('query { shop }')
+          end
+        end
+
+        def test_send_request_raises_an_exception_on_net_http_read_timeout_error
+          config = Config.new(url: 'http://example.org')
+          adapter = HTTPAdapter.new(config)
+
+          stub_request(:post, 'http://example.org').to_raise(Net::ReadTimeout)
+
+          assert_raises ReadTimeoutError do
+            adapter.request('query { shop }')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Timeout errors are common, and we don't want people to worry about handling lower level net/http timeout errors.

By catching `GraphQL::Client::Error`, you now also catch timeout errors as well. There are specific timeout errors if you need more granularity in your handling:

* `GraphQL::Client::OpenTimeoutError`
* `GraphQL::Client::ReadTimeoutError`