### PR TITLE
Expose `extensions` metadata from GraphQL response

### DIFF
--- a/lib/graphql_client/base.rb
+++ b/lib/graphql_client/base.rb
@@ -33,8 +33,12 @@ module GraphQL
       end
 
       def raw_query(query_string, operation_name: nil, variables: {})
+        raw_query_with_extensions(query_string, operation_name: operation_name, variables: variables)[0]
+      end
+
+      def raw_query_with_extensions(query_string, operation_name: nil, variables: {})
         response = adapter.request(query_string, operation_name: operation_name, variables: variables)
-        ResponseObject.new(response.data)
+        [ResponseObject.new(response.data), ResponseObject.new(response.extensions)]
       end
 
       private

--- a/lib/graphql_client/response.rb
+++ b/lib/graphql_client/response.rb
@@ -14,7 +14,7 @@ module GraphQL
         @body = response
         @data = data
         @errors = errors.to_a
-        @extensions = extensions.to_a
+        @extensions = extensions
       end
     end
   end

--- a/test/graphql_client/response_object_test.rb
+++ b/test/graphql_client/response_object_test.rb
@@ -3,6 +3,12 @@ require 'test_helper'
 module GraphQL
   module Client
     class ResponseObjectTest < Minitest::Test
+      def test_builds_response_objects_from_nil
+        result = ResponseObject.new(nil)
+
+        assert_equal({}, result.data)
+      end
+
       def test_builds_response_objects_from_hashes
         result = ResponseObject.new(
           'myshop' => {

--- a/test/graphql_client/response_test.rb
+++ b/test/graphql_client/response_test.rb
@@ -34,21 +34,19 @@ module GraphQL
       def test_initialize_sets_extensions
         body = {
           data: { id: 1 },
-          extensions: [
-            { foo: 'bar' }
-          ]
+          extensions: { foo: 'bar' }
         }
 
         response = Response.new(body.to_json)
 
-        assert_equal [{ 'foo' => 'bar' }], response.extensions
+        assert_equal({ 'foo' => 'bar' }, response.extensions)
       end
 
-      def test_initialize_sets_extensions_default
+      def test_initialize_with_no_extensions_sets_it_to_nil
         body = { data: { id: 1 } }
         response = Response.new(body.to_json)
 
-        assert_equal [], response.extensions
+        assert_nil response.extensions
       end
 
       def test_initialize_raises_error_if_response_contains_errors_without_data


### PR DESCRIPTION
Data such as this is now being returned from the Shopify GraphQL API:
```
{
  "data": ...,
  "extensions": {
    "cost": {
      "requestedQueryCost": 101,
      "actualQueryCost": 3,
      "throttleStatus": {
        "maximumAvailable": 1000,
        "currentlyAvailable": 997,
        "restoreRate": 50
      }
    }
  }
}
```

Currently the client is parsing the `extensions` metadata but it isn't exposed to the caller. I'm in the process of creating a backfill job in https://github.com/Shopify/launchpad/pull/1191 that will rely on the `extensions.cost.throttleStatus` data to throttle it's queries so as not to use up the entire quota for any given shop.

The approach taken here is to extend the `GraphQL::Client::Base` interface with a new `raw_query_with_extensions` method that will return a result containing the `data` and the `extensions`. I also considered extending `raw_query` with an optional param, like `return_extensions: false`, that would control the return type of `raw_query`. The approach I ended up going with here felt cleaner to me.

Also it was a toss up between returning `data` and `extensions` as a tuple or introducing a new class as a container for these. I feel like the tuple is more lightweight and makes for a simple API when combined with array destructuring. Thoughts?

cc @Shopify/plus-internal-dev, @nneufeld 
