### PR TITLE
Remove deploy to RubyGems from Shipit config.

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,3 @@
 deploy:
   override:
     - bundle exec rake build
-    - bundle exec package_cloud push shopify/gems pkg/*.gem


### PR DESCRIPTION
I'm attempting to clear out the undeployed commits in [this repos Shipit stack](https://shipit.shopify.io/shopify/graphql-ruby-client/rubygems). However it won't progress past a version that's already been pushed to RubyGems. The plan is to revert this commit after the undeployed commits are cleared out.