### PR TITLE
Update gemspec and 0.4.1 bump

### DIFF
--- a/graphql_ruby_client.gemspec
+++ b/graphql_ruby_client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary = ''
   s.test_files = `git ls-files -- {test}/*`.split("\n")
   s.version = GraphQL::Client::VERSION
-  s.executables << 'graphql-client'
+  s.executables = 'graphql-client'
 
   s.add_runtime_dependency 'graphql_schema', '~> 0.1.5'
 

--- a/lib/graphql_client/version.rb
+++ b/lib/graphql_client/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Client
-    VERSION = '0.4.0'
+    VERSION = '0.4.1'
   end
 end


### PR DESCRIPTION
Our deployment tool looks like it has a newer version of the `gem` command that blows up when adding executables as opposed to just setting the list. I've tested that the executable still works when locally installing this package.