### PR TITLE
Add missing require to fix NameError

### DIFF
--- a/lib/graphql_client/adapters/http_adapter.rb
+++ b/lib/graphql_client/adapters/http_adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'net/http'
+
 module GraphQL
   module Client
     module Adapters


### PR DESCRIPTION
As I tried to use the client in a new project where 'net/http' hadn't already been required an error was raised:

> uninitialized constant GraphQL::Client::Adapters::HTTPAdapter::Net (NameError)

This PR simply adds the missing require statement.